### PR TITLE
Update font sizes for better mobile use

### DIFF
--- a/src/Caesar/CaesarList.css
+++ b/src/Caesar/CaesarList.css
@@ -1,0 +1,3 @@
+.CaesarList {
+  font-size: 16px;
+}

--- a/src/Caesar/CaesarList.tsx
+++ b/src/Caesar/CaesarList.tsx
@@ -10,7 +10,7 @@ type Props = {
 class CaesarList extends React.Component<Props> {
   public render() {
     return (
-      <pre className="CaesarList-list">
+      <pre className="CaesarList">
         {this.renderListItems()}
       </pre>
     );

--- a/src/index.css
+++ b/src/index.css
@@ -9,3 +9,7 @@ body {
 .navbar-brand {
   font-size: 20px;
 }
+
+.form-control {
+  font-size: 16px;
+}


### PR DESCRIPTION
On iOS input boxes with a font size smaller than 16px cause the page to
zoom in when focused. By setting the size to 16px it prevents this
behavior. Also updated the output font size to match.

It's slightly large for a desktop, but if that becomes a problem we can
try using CSS media queries to specialize the behavior a bit more.