### PR TITLE
Refactor local storage code

### DIFF
--- a/src/Braille/BrailleStream.tsx
+++ b/src/Braille/BrailleStream.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button, ButtonGroup, ButtonToolbar } from 'react-bootstrap';
 import BrailleCharacter from './BrailleCharacter';
-import LocalStorage from 'Data/LocalStorage';
+import LocalStorageComponent from 'Data/LocalStorageComponent';
 import {
   BrailleCharacter as Character,
   BrailleDot as Dot,
@@ -21,7 +21,7 @@ type SavedState = {
   stream: Encoding[],
 };
 
-class BrailleStream extends React.Component<Props, State> {
+class BrailleStream extends LocalStorageComponent<Props, State, SavedState> {
   private readonly _stream: Stream = new Stream();
   private readonly _character: Character = new Character();
 
@@ -32,11 +32,6 @@ class BrailleStream extends React.Component<Props, State> {
       character: this._character,
       stream: this._stream,
     };
-  }
-
-  public componentDidMount() {
-    this.restoreState();
-    this.updateState();
   }
 
   public render() {
@@ -63,29 +58,25 @@ class BrailleStream extends React.Component<Props, State> {
     );
   }
 
-  private saveState() {
-    LocalStorage.setObject<SavedState>('BrailleStream', {
+  protected onSaveState() {
+    return {
       character: this._character.encoding,
       stream: this._stream.chars,
-    });
+    };
   }
 
-  private restoreState() {
-    const savedState = LocalStorage.getObject<SavedState>('BrailleStream');
-
+  protected onRestoreState(savedState: SavedState | null) {
     if (savedState !== null) {
       this._character.encoding = savedState.character;
       this._stream.chars = savedState.stream;
     }
   }
 
-  private updateState() {
+  protected onUpdateState() {
     this.setState({
       character: this._character,
       stream: this._stream,
     });
-
-    this.saveState();
   }
 
   private handleClick(mask: Dot) {

--- a/src/Cipher/Caesar/CaesarStream.tsx
+++ b/src/Cipher/Caesar/CaesarStream.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button, ButtonGroup, ButtonToolbar, FormControl } from 'react-bootstrap';
 import CaesarList from './CaesarList';
-import LocalStorage from 'Data/LocalStorage';
+import LocalStorageComponent from 'Data/LocalStorageComponent';
 import { CaesarString } from 'puzzle-lib';
 import './CaesarStream.css';
 
@@ -15,7 +15,7 @@ type SavedState = {
   text: string,
 };
 
-class CaesarStream extends React.Component<Props, State> {
+class CaesarStream extends LocalStorageComponent<Props, State, SavedState> {
   private readonly _str: CaesarString = new CaesarString();
   private _input: HTMLInputElement;
 
@@ -29,8 +29,7 @@ class CaesarStream extends React.Component<Props, State> {
   }
 
   public componentDidMount() {
-    this.restoreState();
-    this.updateState();
+    super.componentDidMount();
     this._input.focus();
   }
 
@@ -54,27 +53,23 @@ class CaesarStream extends React.Component<Props, State> {
     );
   }
 
-  private saveState() {
-    LocalStorage.setObject<SavedState>('CaesarStream', {
+  protected onSaveState() {
+    return {
       text: this._str.text,
-    });
+    };
   }
 
-  private restoreState() {
-    const savedState = LocalStorage.getObject<SavedState>('CaesarStream');
-
+  protected onRestoreState(savedState: SavedState | null) {
     if (savedState !== null) {
       this._str.text = savedState.text;
     }
   }
 
-  private updateState() {
+  protected onUpdateState() {
     this.setState({
       list: this._str.getRotations(),
       text: this._str.text,
     });
-
-    this.saveState();
   }
 
   private onTextChanged(event: React.SyntheticEvent<FormControl>) {

--- a/src/Cipher/KeyedCipherStreamBase/KeyedCipherStreamBase.tsx
+++ b/src/Cipher/KeyedCipherStreamBase/KeyedCipherStreamBase.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button, ButtonGroup, ButtonToolbar, FormControl, ToggleButton, ToggleButtonGroup } from 'react-bootstrap';
-import LocalStorage from 'Data/LocalStorage';
+import LocalStorageComponent from 'Data/LocalStorageComponent';
 import { KeyedCipherStringBase  } from 'puzzle-lib';
 import './KeyedCipherStreamBase.css';
 
@@ -18,7 +18,7 @@ type SavedState = {
   text: string,
 };
 
-class KeyedCipherStreamBase extends React.Component<Props, State> {
+class KeyedCipherStreamBase extends LocalStorageComponent<Props, State, SavedState> {
   private readonly _cipher: KeyedCipherStringBase;
   private _conversion: number = 2;
   private _input: HTMLInputElement;
@@ -36,8 +36,7 @@ class KeyedCipherStreamBase extends React.Component<Props, State> {
   }
 
   public componentDidMount() {
-    this.restoreState();
-    this.updateState();
+    super.componentDidMount();
     this._input.focus();
   }
 
@@ -79,17 +78,15 @@ class KeyedCipherStreamBase extends React.Component<Props, State> {
     );
   }
 
-  private saveState() {
-    LocalStorage.setObject<SavedState>('KeyedCipherStreamBase', {
+  protected onSaveState() {
+    return {
       conversion: this._conversion,
       key: this._cipher.key,
       text: this._cipher.text,
-    });
+    };
   }
 
-  private restoreState() {
-    const savedState = LocalStorage.getObject<SavedState>('KeyedCipherStreamBase');
-
+  protected onRestoreState(savedState: SavedState | null) {
     if (savedState !== null) {
       this._cipher.text = savedState.text;
       this._cipher.key = savedState.key;
@@ -97,15 +94,13 @@ class KeyedCipherStreamBase extends React.Component<Props, State> {
     }
   }
 
-  private updateState() {
+  protected onUpdateState() {
     this.setState({
       conversion: this._conversion,
       key: this._cipher.key,
       output: this._conversion === 1 ? this._cipher.encrypt() : this._cipher.decrypt(),
       text: this._cipher.text,
     });
-
-    this.saveState();
   }
 
   private onTextChanged(event: React.SyntheticEvent<FormControl>) {

--- a/src/Data/LocalStorageComponent.ts
+++ b/src/Data/LocalStorageComponent.ts
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import LocalStorage from './LocalStorage';
+
+abstract class LocalStorageComponent<P = {}, S = {}, SavedState = {}> extends React.Component<P, S> {
+  public componentDidMount() {
+    this.restoreState();
+    this.updateState();
+  }
+
+  protected updateState() {
+    this.onUpdateState();
+    this.saveState();
+  }
+
+  protected abstract onUpdateState(): void;
+  protected abstract onSaveState(): SavedState;
+  protected abstract onRestoreState(savedState: SavedState | null): void;
+
+  private getClassName() {
+    // tslint:disable-next-line:no-any
+    return (this as any).constructor.name;
+  }
+
+  private saveState() {
+    LocalStorage.setObject<SavedState>(this.getClassName(), this.onSaveState());
+  }
+
+  private restoreState() {
+    this.onRestoreState(LocalStorage.getObject<SavedState>(this.getClassName()));
+  }
+}
+
+export default LocalStorageComponent;

--- a/src/Morse/MorseStream.tsx
+++ b/src/Morse/MorseStream.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button, ButtonGroup, ButtonToolbar, Well } from 'react-bootstrap';
 import { MorseCharacter as Character } from 'puzzle-lib';
-import LocalStorage from 'Data/LocalStorage';
+import LocalStorageComponent from 'Data/LocalStorageComponent';
 import './MorseStream.css';
 
 type Props = {};
@@ -15,7 +15,7 @@ type SavedState = {
   stream: string,
 };
 
-class MorseStream extends React.Component<Props, State> {
+class MorseStream extends LocalStorageComponent<Props, State, SavedState> {
   private readonly _character: Character = new Character();
   private _stream: string = '';
 
@@ -26,11 +26,6 @@ class MorseStream extends React.Component<Props, State> {
       character: this._character,
       stream: this._stream,
     };
-  }
-
-  public componentDidMount() {
-    this.restoreState();
-    this.updateState();
   }
 
   public render() {
@@ -63,29 +58,25 @@ class MorseStream extends React.Component<Props, State> {
     );
   }
 
-  private saveState() {
-    LocalStorage.setObject<SavedState>('MorseStream', {
+  protected onSaveState() {
+    return {
       character: this._character.morseString,
       stream: this._stream,
-    });
+    };
   }
 
-  private restoreState() {
-    const savedState = LocalStorage.getObject<SavedState>('MorseStream');
-
+  protected onRestoreState(savedState: SavedState | null) {
     if (savedState !== null) {
       this._character.morseString = savedState.character;
       this._stream = savedState.stream;
     }
   }
 
-  private updateState() {
+  protected onUpdateState() {
     this.setState({
       character: this._character,
       stream: this._stream,
     });
-
-    this.saveState();
   }
 
   private handleDot() {

--- a/src/Semaphore/SemaphoreStream.tsx
+++ b/src/Semaphore/SemaphoreStream.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button, ButtonGroup, ButtonToolbar } from 'react-bootstrap';
 import SemaphoreCharacter from './SemaphoreCharacter';
-import LocalStorage from 'Data/LocalStorage';
+import LocalStorageComponent from 'Data/LocalStorageComponent';
 import {
   SemaphoreCharacter as Character,
   SemaphoreDirection as Direction
@@ -19,8 +19,8 @@ type SavedState = {
   stream: string,
 };
 
-class SemaphoreStream extends React.Component<Props, State> {
-  private readonly _character: Character = new Character(0, 0);
+class SemaphoreStream extends LocalStorageComponent<Props, State, SavedState> {
+  private readonly _character: Character = new Character();
   private _stream: string = '';
 
   constructor(props: Props) {
@@ -30,11 +30,6 @@ class SemaphoreStream extends React.Component<Props, State> {
       character: this._character,
       stream: '',
     };
-  }
-
-  public componentDidMount() {
-    this.restoreState();
-    this.updateState();
   }
 
   public render() {
@@ -61,29 +56,25 @@ class SemaphoreStream extends React.Component<Props, State> {
     );
   }
 
-  private saveState() {
-    LocalStorage.setObject<SavedState>('SemaphoreStream', {
+  protected onSaveState() {
+    return {
       directions: this._character.directions,
       stream: this._stream,
-    });
+    };
   }
 
-  private restoreState() {
-    const savedState = LocalStorage.getObject<SavedState>('SemaphoreStream');
-
+  protected onRestoreState(savedState: SavedState | null) {
     if (savedState !== null) {
       this._character.directions = savedState.directions;
       this._stream = savedState.stream;
     }
   }
 
-  private updateState() {
+  protected onUpdateState() {
     this.setState({
       character: this._character,
       stream: this._stream,
     });
-
-    this.saveState();
   }
 
   private handleChange(type: string, direction: Direction) {

--- a/src/Views/Cipher/Autokey.tsx
+++ b/src/Views/Cipher/Autokey.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import AutokeyStream from 'Cipher/Autokey/AutokeyStream';
-import './Caesar.css';
+import './Autokey.css';
 
 class Autokey extends React.Component {
   public render() {

--- a/src/Views/Cipher/Vigenere.tsx
+++ b/src/Views/Cipher/Vigenere.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import VigenereStream from 'Cipher/Vigenere/VigenereStream';
-import './Caesar.css';
+import './Vigenere.css';
 
 class Vigenere extends React.Component {
   public render() {

--- a/src/Views/Reference/CharacterEncodings.tsx
+++ b/src/Views/Reference/CharacterEncodings.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Tab, Tabs } from 'react-bootstrap';
 import AsciiTable from 'Conversion/Character/AsciiTable';
 import OrdinalTable from 'Conversion/Character/OrdinalTable';
-import LocalStorage from 'Data/LocalStorage';
+import LocalStorageComponent from 'Data/LocalStorageComponent';
 import './CharacterEncodings.css';
 
 type Props = {};
@@ -14,7 +14,7 @@ type SavedState = {
   activeKey: number,
 };
 
-class CharacterEncodings extends React.Component<Props, State> {
+class CharacterEncodings extends LocalStorageComponent<Props, State, SavedState> {
   private _activeKey: number = 1;
 
   constructor(props: Props) {
@@ -23,11 +23,6 @@ class CharacterEncodings extends React.Component<Props, State> {
     this.state = {
       activeKey: this._activeKey,
     };
-  }
-
-  public componentDidMount() {
-    this.restoreState();
-    this.updateState();
   }
 
   public render() {
@@ -53,26 +48,22 @@ class CharacterEncodings extends React.Component<Props, State> {
     );
   }
 
-  private updateState() {
-    this.setState({
+  protected onSaveState() {
+    return {
       activeKey: this._activeKey,
-    });
-
-    this.saveState();
+    };
   }
 
-  private saveState() {
-    LocalStorage.setObject<SavedState>('CharacterEncodings', {
-      activeKey: this._activeKey,
-    });
-  }
-
-  private restoreState() {
-    const savedState = LocalStorage.getObject<SavedState>('CharacterEncodings');
-
+  protected onRestoreState(savedState: SavedState | null) {
     if (savedState !== null) {
       this._activeKey = savedState.activeKey;
     }
+  }
+
+  protected onUpdateState() {
+    this.setState({
+      activeKey: this._activeKey,
+    });
   }
 
   private onTabSelect(activeKey: number) {


### PR DESCRIPTION
Pulled out the local storage code to a base class which handles the save
and restore. During a previous refactor two similar tools ended up
sharing the same storage slot. Hopefully this helps prevent that in the
future.

Also fixed a couple of bugs