### PR TITLE
Semaphore bug with numbers

### DIFF
--- a/src/Semaphore/SemaphoreStream.tsx
+++ b/src/Semaphore/SemaphoreStream.tsx
@@ -99,9 +99,9 @@ class SemaphoreStream extends LocalStorageComponent<Props, State, SavedState> {
   }
 
   private handleNext() {
-    const ch = this._character.toString();
-    if (ch.length > 0) {
-      this._stream += ch;
+    const matches = this._character.getExactMatches();
+    if (matches.length > 0) {
+      this._stream += matches[0].toString();
       this._character.clear();
 
       this.updateState();


### PR DESCRIPTION
The stream doesn't currently support adding numbers. When I updated the
library I didn't update the view to handle the possibility that there
could be multiple matches.

Full number support will come later.